### PR TITLE
Initialize Next.js TypeScript todo app

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# nextjs_app
+# Next.js Todo App
+
+이 프로젝트는 Node.js 22 버전과 TypeScript를 이용하여 만든 간단한 Todo 리스트 예제입니다. Next.js의 최신 버전을 사용하며, 기본적인 앱 구조를 제공합니다.
+
+## 주요 스크립트
+- `npm run dev` – 개발 서버 실행
+- `npm run build` – 프로덕션 빌드
+- `npm run start` – 프로덕션 모드로 실행
+
+## 디렉터리 구조
+- `app/` – Next.js 앱 라우팅을 담당하는 디렉터리
+  - `layout.tsx` – 기본 레이아웃 정의
+  - `page.tsx` – 메인 페이지로 Todo 리스트를 출력
+  - `globals.css` – 전역 스타일
+- `components/` – 재사용 가능한 컴포넌트 모음
+  - `TodoList.tsx` – Todo 리스트 로직 및 UI
+
+## 시작하기
+1. 의존성 설치
+   ```bash
+   npm install
+   ```
+2. 개발 서버 실행
+   ```bash
+   npm run dev
+   ```
+3. 브라우저에서 `http://localhost:3000`으로 접속하여 확인
+
+## 추가 아이디어
+- 상태 관리를 위해 context나 recoil 등 다른 라이브러리 사용 가능
+- 데이터 영속화를 위해 로컬 스토리지 또는 백엔드 연동 고려

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,5 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Todo App',
+  description: 'A simple Next.js todo list application',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ko">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,10 @@
+import TodoList from '../components/TodoList';
+
+export default function Home() {
+  return (
+    <main style={{ padding: '1rem' }}>
+      <h1>Todo List</h1>
+      <TodoList />
+    </main>
+  );
+}

--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useState } from 'react';
+
+interface Todo {
+  id: number;
+  text: string;
+  completed: boolean;
+}
+
+export default function TodoList() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [input, setInput] = useState('');
+
+  const addTodo = () => {
+    if (!input.trim()) return;
+    const newTodo: Todo = {
+      id: Date.now(),
+      text: input.trim(),
+      completed: false,
+    };
+    setTodos([...todos, newTodo]);
+    setInput('');
+  };
+
+  const toggleTodo = (id: number) => {
+    setTodos(todos.map(todo => todo.id === id ? { ...todo, completed: !todo.completed } : todo));
+  };
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        placeholder="새 할 일"
+      />
+      <button onClick={addTodo}>추가</button>
+      <ul>
+        {todos.map(todo => (
+          <li key={todo.id} onClick={() => toggleTodo(todo.id)} style={{ cursor: 'pointer', textDecoration: todo.completed ? 'line-through' : 'none' }}>
+            {todo.text}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "nextjs_app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "typescript": "latest",
+    "@types/react": "latest",
+    "@types/node": "latest"
+  },
+  "engines": {
+    "node": "22.x"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up a minimal Next.js app with TypeScript
- add a simple Todo list component as an example
- include config files and documentation for getting started

## Testing
- `npm run build` *(fails: next not found)*