### PR TITLE
Add NestJS backend example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,19 @@
 ## 추가 아이디어
 - 상태 관리를 위해 context나 recoil 등 다른 라이브러리 사용 가능
 - 데이터 영속화를 위해 로컬 스토리지 또는 백엔드 연동 고려
+## 백엔드 연동 예시 (NestJS + PostgreSQL)
+`backend` 디렉터리에는 NestJS 기반의 간단한 API 서버가 포함되어 있습니다. TypeORM을 사용해 PostgreSQL과 연결하며 Todo 데이터를 영속 저장합니다.
+
+### 사용 방법
+1. 백엔드 폴더로 이동 후 의존성 설치
+   ```bash
+   cd backend
+   npm install
+   ```
+2. 개발 서버 실행
+   ```bash
+   npm run start:dev
+   ```
+3. 브라우저나 API 클라이언트에서 `http://localhost:4000/todos` 경로를 호출해 데이터를 주고 받을 수 있습니다.
+
+데이터베이스 접속 설정은 `backend/src/app.module.ts` 파일에서 확인할 수 있으며, 실제 배포 시에는 환경 변수로 분리해 사용하면 좋습니다.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,21 @@
+# Todo Backend (NestJS + PostgreSQL)
+
+이 디렉터리는 NestJS와 PostgreSQL을 사용한 간단한 Todo API 예제를 제공합니다.
+
+## 실행 방법
+
+1. 의존성 설치
+   ```bash
+   npm install
+   ```
+2. 개발 서버 실행
+   ```bash
+   npm run start:dev
+   ```
+
+서버가 시작되면 `http://localhost:4000` 에서 동작하며, 주요 엔드포인트는 다음과 같습니다.
+
+- `GET /todos` : Todo 목록 조회
+- `POST /todos` : 새 Todo 생성 (`text` 필드 필요)
+
+데이터베이스 접속 정보는 `src/app.module.ts` 파일의 `TypeOrmModule.forRoot()` 옵션에서 설정합니다. 실제 환경에서는 환경 변수로 분리하여 관리하는 것이 좋습니다.

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "todo-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "build": "nest build"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.17",
+    "pg": "^8.9.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TodosModule } from './todos/todos.module';
+import { Todo } from './todos/todo.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: 'localhost',
+      port: 5432,
+      username: 'postgres',
+      password: 'postgres',
+      database: 'todo_db',
+      entities: [Todo],
+      synchronize: true, // 개발 시에만 사용
+    }),
+    TodosModule,
+  ],
+})
+export class AppModule {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,9 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(4000);
+  console.log('Backend running on http://localhost:4000');
+}
+bootstrap();

--- a/backend/src/todos/todo.entity.ts
+++ b/backend/src/todos/todo.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Todo {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  text: string;
+
+  @Column({ default: false })
+  completed: boolean;
+}

--- a/backend/src/todos/todos.controller.ts
+++ b/backend/src/todos/todos.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { TodosService } from './todos.service';
+
+@Controller('todos')
+export class TodosController {
+  constructor(private readonly todosService: TodosService) {}
+
+  @Get()
+  findAll() {
+    return this.todosService.findAll();
+  }
+
+  @Post()
+  create(@Body('text') text: string) {
+    return this.todosService.create(text);
+  }
+}

--- a/backend/src/todos/todos.module.ts
+++ b/backend/src/todos/todos.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TodosController } from './todos.controller';
+import { TodosService } from './todos.service';
+import { Todo } from './todo.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Todo])],
+  controllers: [TodosController],
+  providers: [TodosService],
+})
+export class TodosModule {}

--- a/backend/src/todos/todos.service.ts
+++ b/backend/src/todos/todos.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Todo } from './todo.entity';
+
+@Injectable()
+export class TodosService {
+  constructor(
+    @InjectRepository(Todo)
+    private readonly todoRepository: Repository<Todo>,
+  ) {}
+
+  findAll() {
+    return this.todoRepository.find();
+  }
+
+  create(text: string) {
+    const todo = this.todoRepository.create({ text });
+    return this.todoRepository.save(todo);
+  }
+}

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}


### PR DESCRIPTION
## Summary
- add backend directory with NestJS/TypeORM setup using PostgreSQL
- document how to run the new backend server in the README

## Testing
- `npm run build` *(fails: next not found)*